### PR TITLE
指示書システム改善

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python -c ' *)",
+      "WebSearch",
+      "Bash(aws dynamodb *)"
+    ]
+  }
+}

--- a/static/js/meziro_upload.js
+++ b/static/js/meziro_upload.js
@@ -10,6 +10,7 @@ const progressBar = document.getElementById("progressBar");
 
 let selectedFiles = []; // 選択されたファイルを保持
 let totalSize = 0;
+let selectedImages = []; // 画像添付欄で選択した画像ファイルを保持
 
 // 100件以上のファイルを取得するために必要な関数
 async function readAllEntries(reader) {
@@ -360,6 +361,11 @@ async function uploadFiles(files) {
     formData.append("crown_type", crownType);
     formData.append("teeth", JSON.stringify(selectedTeeth)); // JSON文字列として送信
 
+    // ▼ 画像添付ファイルを追加
+    selectedImages.forEach((imgFile) => {
+        formData.append("images[]", imgFile);
+    });
+
     // ▼ ファイル処理
     let totalBytes = files.reduce((sum, file) => sum + file.size, 0);
     let uploadedBytes = 0;
@@ -412,6 +418,8 @@ async function uploadFiles(files) {
                 showStatus(result.message || "アップロード成功", "success");
                 fileList.innerHTML = "";
                 selectedFiles = [];
+                selectedImages = [];
+                renderImageThumbnails();
                 updateButtonState();
                 progressContainer.style.display = "none";
                 // input-zone内の全フィールドをリセット（readonlyは除く）
@@ -679,6 +687,43 @@ document.addEventListener("DOMContentLoaded", function () {
             }
         );
     });
+});
+
+// ---- 画像添付エリア ----
+function renderImageThumbnails() {
+    const container = document.getElementById("imageThumbnails");
+    container.innerHTML = "";
+    selectedImages.forEach((file, index) => {
+        const item = document.createElement("div");
+        item.className = "image-thumb-item";
+
+        const img = document.createElement("img");
+        img.src = URL.createObjectURL(file);
+        img.title = file.name;
+        img.addEventListener("click", () => window.open(img.src, "_blank"));
+
+        const removeBtn = document.createElement("button");
+        removeBtn.className = "image-thumb-remove";
+        removeBtn.textContent = "×";
+        removeBtn.addEventListener("click", () => {
+            URL.revokeObjectURL(img.src);
+            selectedImages.splice(index, 1);
+            renderImageThumbnails();
+        });
+
+        item.appendChild(img);
+        item.appendChild(removeBtn);
+        container.appendChild(item);
+    });
+}
+
+document.getElementById("imageInput").addEventListener("change", function (e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    selectedImages.push(file);
+    renderImageThumbnails();
+    // inputをリセットして同じ画像を再選択できるようにする
+    this.value = "";
 });
 
 document.getElementById("uploadButton").addEventListener("click", function () {

--- a/static/js/meziro_upload.js
+++ b/static/js/meziro_upload.js
@@ -299,7 +299,7 @@ async function readEntryRecursively(entry) {
 
 // ドラッグ＆ドロップされたアイテムを処理
 async function uploadFiles(files) {
-    const isPrescriptionPage = !!document.getElementById("PatientNameKana");
+    const isPrescriptionPage = !!document.getElementById("ChartNumber");
     if (files.length === 0 && !isPrescriptionPage) return;
 
     const formData = new FormData();
@@ -308,11 +308,15 @@ async function uploadFiles(files) {
     formData.append("csrf_token", csrf_token);
 
     // テキスト系入力を収集
-    const businessName = document.getElementById("businessName").value;
+    const businessName = document.getElementById("businessName") ? document.getElementById("businessName").value : "";
     const userName = document.getElementById("userName").value;
     const userEmail = document.getElementById("userEmail").value;
-    const patientName = document.getElementById("PatientName").value;
-    const patientNameKana = document.getElementById("PatientNameKana") ? document.getElementById("PatientNameKana").value : "";
+    const patientLastName = (document.getElementById("PatientLastName")?.value || "").trim();
+    const patientFirstName = (document.getElementById("PatientFirstName")?.value || "").trim();
+    const patientName = [patientLastName, patientFirstName].filter(Boolean).join("　");
+    const patientLastNameKana = (document.getElementById("PatientLastNameKana")?.value || "").trim();
+    const patientFirstNameKana = (document.getElementById("PatientFirstNameKana")?.value || "").trim();
+    const patientNameKana = [patientLastNameKana, patientFirstNameKana].filter(Boolean).join("　");
     const chartNumber = document.getElementById("ChartNumber") ? document.getElementById("ChartNumber").value : "";
     const appointmentDate = document.getElementById("appointmentDate").value;
     const appointmentHour = document.getElementById("appointmentHour").value;
@@ -326,18 +330,24 @@ async function uploadFiles(files) {
     );
     const crownType = crownRadio ? crownRadio.value : "";
 
-    // teeth[]（チェックボックス）
-    const selectedTeeth = [];
-    document.querySelectorAll('input[name="teeth[]"]:checked').forEach((cb) => {
-        selectedTeeth.push(cb.value);
+    // teeth（トグルセル）
+    const teethAbutment     = [];
+    const teethMissing      = [];
+    const teethFabrication  = [];
+    document.querySelectorAll('.tooth-cell').forEach((cell) => {
+        const state = parseInt(cell.dataset.state || 0);
+        if (state === 1) teethAbutment.push(cell.dataset.value);
+        else if (state === 2) teethMissing.push(cell.dataset.value);
+        else if (state === 3) teethFabrication.push(cell.dataset.value);
     });
+    const selectedTeeth = [...teethAbutment, ...teethMissing, ...teethFabrication];
 
     // ▼ 必須フィールドのバリデーション
     if (
-        !businessName ||
         !userName ||
         !userEmail ||
-        !patientName ||
+        !patientLastName ||
+        !patientFirstName ||
         !appointmentDate ||
         !appointmentHour ||
         !projectType
@@ -359,7 +369,10 @@ async function uploadFiles(files) {
     formData.append("shade", shade);
     formData.append("userMessage", userMessage);
     formData.append("crown_type", crownType);
-    formData.append("teeth", JSON.stringify(selectedTeeth)); // JSON文字列として送信
+    formData.append("teeth", JSON.stringify(selectedTeeth));
+    formData.append("teeth_abutment", JSON.stringify(teethAbutment));
+    formData.append("teeth_missing", JSON.stringify(teethMissing));
+    formData.append("teeth_fabrication", JSON.stringify(teethFabrication));
 
     // ▼ 画像添付ファイルを追加
     selectedImages.forEach((imgFile) => {
@@ -434,6 +447,8 @@ async function uploadFiles(files) {
                         el.value = "";
                     }
                 });
+                // シェードシステムをリセット後、選択肢も更新
+                if (typeof updateShadeOptions === "function") updateShadeOptions();
             } else {
                 // 修正：throw ではなく直接処理
                 console.error("HTTPエラー:", xhr.status, xhr.statusText);
@@ -689,6 +704,19 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 });
 
+// カルテ番号「不明」チェックボックス
+function toggleChartUnknown(checkbox) {
+    const field = document.getElementById("ChartNumber");
+    if (checkbox.checked) {
+        field.value = "不明";
+        field.disabled = true;
+    } else {
+        field.value = "";
+        field.disabled = false;
+        field.focus();
+    }
+}
+
 // ---- 画像添付エリア ----
 function renderImageThumbnails() {
     const container = document.getElementById("imageThumbnails");
@@ -718,20 +746,41 @@ function renderImageThumbnails() {
 }
 
 document.getElementById("imageInput").addEventListener("change", function (e) {
-    const file = e.target.files[0];
-    if (!file) return;
-    selectedImages.push(file);
+    Array.from(e.target.files).forEach(file => {
+        if (file) selectedImages.push(file);
+    });
     renderImageThumbnails();
-    // inputをリセットして同じ画像を再選択できるようにする
     this.value = "";
+});
+
+// 画像エリアのドラッグ＆ドロップ
+const imageUploadArea = document.getElementById("imageUploadArea");
+
+imageUploadArea.addEventListener("dragover", (e) => {
+    e.preventDefault();
+    imageUploadArea.classList.add("drag-over");
+});
+
+imageUploadArea.addEventListener("dragleave", () => {
+    imageUploadArea.classList.remove("drag-over");
+});
+
+imageUploadArea.addEventListener("drop", (e) => {
+    e.preventDefault();
+    imageUploadArea.classList.remove("drag-over");
+    const files = Array.from(e.dataTransfer.files).filter(f => f.type.startsWith("image/"));
+    if (files.length === 0) return;
+    files.forEach(file => selectedImages.push(file));
+    renderImageThumbnails();
 });
 
 document.getElementById("uploadButton").addEventListener("click", function () {
     const requiredFields = [
-        "businessName",
         "userName",
         "userEmail",
-        "PatientName",
+        "PatientLastName",
+        "PatientFirstName",
+        "ChartNumber",
         "appointmentDate",
         "appointmentHour",
         "projectType",
@@ -748,7 +797,10 @@ document.getElementById("uploadButton").addEventListener("click", function () {
     });
 
     // 未入力のものを赤くする
+    const chartUnknown = document.getElementById("chartUnknown");
     requiredFields.forEach((id) => {
+        // カルテ番号は「不明」チェック時はスキップ
+        if (id === "ChartNumber" && chartUnknown && chartUnknown.checked) return;
         const element = document.getElementById(id);
         if (element && !element.value.trim()) {
             element.classList.add("input-error");

--- a/templates/common/base.html
+++ b/templates/common/base.html
@@ -244,7 +244,7 @@
               </li> 
 
               <li class="nav-item">
-                <a href="{{ url_for('users.account_me') }}"
+                <a href="{{ url_for('main.clinic_dashboard') if not current_user.administrator else url_for('users.account_me') }}"
                   class="navbar-text ms-3 no-underline {% if current_user.administrator %}admin-name{% else %}user-name{% endif %}">
                   {{ current_user.display_name[:10] }}
                 </a>

--- a/templates/main/clinic_dashboard.html
+++ b/templates/main/clinic_dashboard.html
@@ -2,8 +2,8 @@
 {% block title %}歯科医院メニュー | 渋谷歯科技工所{% endblock %}
 {% block content %}
 
-<div class="container py-5" style="max-width: 600px;">
-  <h2 class="mb-4 text-center fw-bold">歯科医院メニュー</h2>
+<div class="container pb-5" style="max-width: 600px;">
+  <h2 class="mb-4 text-center fw-bold">{{ clinic_name }}</h2>
 
   <div class="d-grid gap-3">
 
@@ -12,8 +12,8 @@
         <div class="card-body d-flex align-items-center p-4">
           <span style="font-size: 2rem; margin-right: 1rem;">📋</span>
           <div>
-            <div class="fw-bold fs-5">新規指示書</div>
-            <div class="text-muted small">新しい技工指示書を作成します</div>
+            <div class="fw-bold fs-5">新規歯科技工指示書</div>
+            <div class="text-muted small">新しい歯科技工指示書を作成します</div>
           </div>
         </div>
       </div>
@@ -24,7 +24,7 @@
         <div class="card-body d-flex align-items-center p-4">
           <span style="font-size: 2rem; margin-right: 1rem;">📂</span>
           <div>
-            <div class="fw-bold fs-5">作成済み指示書</div>
+            <div class="fw-bold fs-5">依頼済み指示書</div>
             <div class="text-muted small">過去に送信した指示書を確認します</div>
           </div>
         </div>
@@ -42,6 +42,20 @@
         </div>
       </div>
     </a>
+
+    {% if current_user.is_administrator %}
+    <a href="{{ url_for('main.clinic_list') }}" class="text-decoration-none">
+      <div class="card shadow-sm border-danger">
+        <div class="card-body d-flex align-items-center p-4">
+          <span style="font-size: 2rem; margin-right: 1rem;">🏥</span>
+          <div>
+            <div class="fw-bold fs-5">登録歯科医院一覧</div>
+            <div class="text-muted small">登録済みの歯科医院を確認します（管理者専用）</div>
+          </div>
+        </div>
+      </div>
+    </a>
+    {% endif %}
 
   </div>
 </div>

--- a/templates/main/clinic_list.html
+++ b/templates/main/clinic_list.html
@@ -1,0 +1,119 @@
+{% extends "common/base.html" %}
+{% block title %}登録歯科医院一覧 | 渋谷歯科技工所{% endblock %}
+{% block content %}
+
+<style>
+    .page-header {
+        background-color: rgb(243, 244, 245);
+        text-align: center;
+        padding: 20px;
+        color: #7c1820;
+        margin-bottom: 20px;
+        margin-top: -2rem;
+    }
+    .dentist-list {
+        font-size: 0.85em;
+        color: #555;
+        margin: 0;
+        padding-left: 1em;
+        white-space: nowrap;
+    }
+    .clinic-id-badge {
+        font-size: 0.8em;
+        background-color: #e9ecef;
+        color: #495057;
+        border-radius: 4px;
+        padding: 1px 7px;
+    }
+    .badge-clinic {
+        font-size: 0.75em;
+        background-color: #cce5ff;
+        color: #004085;
+        border-radius: 4px;
+        padding: 2px 8px;
+        white-space: nowrap;
+    }
+    .badge-lab {
+        font-size: 0.75em;
+        background-color: #d4edda;
+        color: #155724;
+        border-radius: 4px;
+        padding: 2px 8px;
+        white-space: nowrap;
+    }
+</style>
+
+<div class="page-header">
+    <h2>登録歯科医院一覧</h2>
+</div>
+
+<div class="container-fluid px-4">
+
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <p class="text-muted mb-0">登録医院数：{{ clinics | length }} 件</p>
+        <a href="{{ url_for('main.clinic_new') }}" class="btn btn-danger btn-sm">＋ 新規医院登録</a>
+    </div>
+
+    {% if clinics %}
+    <table class="table table-hover table-bordered align-middle w-100">
+        <thead class="table-dark">
+            <tr>
+                <th style="width:80px;">ID</th>
+                <th style="width:90px;">種別</th>
+                <th>名称</th>
+                <th>担当者</th>
+                <th>メールアドレス</th>
+                <th>電話番号</th>
+                <th>所在地</th>
+                <th style="min-width: 140px;">担当医師</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for c in clinics %}
+            <tr style="cursor: pointer;" onclick="location.href='{{ url_for('main.clinic_view', user_id=c.user_id) }}'">
+                <td><span class="clinic-id-badge">{{ c.clinic_id or '—' }}</span></td>
+                <td>
+                    {% if c.account_type == 'lab' %}
+                    <span class="badge-lab">歯科技工所</span>
+                    {% else %}
+                    <span class="badge-clinic">歯科医院</span>
+                    {% endif %}
+                </td>
+                <td class="fw-bold" style="color: #7c1820;">{{ c.sender_name or c.display_name }}</td>
+                <td>{{ c.full_name or '—' }}</td>
+                <td><a href="mailto:{{ c.email }}" onclick="event.stopPropagation();">{{ c.email }}</a></td>
+                <td>{{ c.phone or '—' }}</td>
+                <td>
+                    {% if c.prefecture or c.address %}
+                        {{ c.prefecture }}{{ c.address }}
+                        {% if c.building %}<br><span class="text-muted small">{{ c.building }}</span>{% endif %}
+                    {% else %}
+                        —
+                    {% endif %}
+                </td>
+                <td>
+                    {% if c.dentists %}
+                    <ul class="dentist-list">
+                        {% for d in c.dentists %}
+                        <li>{{ d }}</li>
+                        {% endfor %}
+                    </ul>
+                    {% else %}
+                    —
+                    {% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <div class="alert alert-info text-center">登録されている歯科医院はありません。</div>
+    {% endif %}
+
+    <div class="text-center mt-3">
+        <a href="{{ url_for('main.clinic_dashboard') }}" class="btn btn-outline-secondary">戻る</a>
+    </div>
+
+</div>
+
+{% endblock %}

--- a/templates/main/clinic_new.html
+++ b/templates/main/clinic_new.html
@@ -1,0 +1,161 @@
+{% extends "common/base.html" %}
+{% block title %}新規医院登録 | 渋谷歯科技工所{% endblock %}
+{% block content %}
+
+<style>
+    .page-header {
+        background-color: rgb(243, 244, 245);
+        text-align: center;
+        padding: 20px;
+        color: #7c1820;
+        margin-bottom: 20px;
+        margin-top: -2rem;
+    }
+    .section-title {
+        font-weight: bold;
+        border-bottom: 2px solid #7c1820;
+        padding-bottom: 4px;
+        margin: 20px 0 12px;
+        color: #7c1820;
+    }
+    .dentist-row {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 6px;
+        align-items: center;
+    }
+    .dentist-row input {
+        flex: 1;
+    }
+    .btn-remove-dentist {
+        color: #dc3545;
+        background: none;
+        border: none;
+        font-size: 1.2em;
+        cursor: pointer;
+        padding: 0 4px;
+    }
+</style>
+
+<div class="page-header">
+    <h2 id="pageTitle">新規登録</h2>
+</div>
+
+<div class="container" style="max-width: 700px;">
+
+    {% with messages = get_flashed_messages() %}
+    {% if messages %}
+    <div class="alert alert-danger">{{ messages[0] }}</div>
+    {% endif %}
+    {% endwith %}
+
+    <form method="POST" action="{{ url_for('main.clinic_new') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+        <div class="section-title">アカウント種別</div>
+
+        <div class="mb-3 d-flex gap-4">
+            <label class="form-check-label d-flex align-items-center gap-2" style="cursor:pointer;">
+                <input type="radio" name="account_type" value="clinic" class="form-check-input" checked onchange="updateAccountType()">
+                歯科医院
+            </label>
+            <label class="form-check-label d-flex align-items-center gap-2" style="cursor:pointer;">
+                <input type="radio" name="account_type" value="lab" class="form-check-input" onchange="updateAccountType()">
+                歯科技工所（DL）
+            </label>
+        </div>
+
+        <div class="section-title" id="sectionInfoTitle">医院情報</div>
+
+        <div class="mb-3">
+            <label class="form-label" id="labelSenderName">医院名 <span class="text-danger">必須</span></label>
+            <input type="text" name="sender_name" id="inputSenderName" class="form-control" placeholder="例：藤田歯科医院" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">担当者名</label>
+            <input type="text" name="full_name" class="form-control" placeholder="例：藤田 融">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">電話番号</label>
+            <input type="tel" name="phone" class="form-control" placeholder="例：0489708000">
+        </div>
+
+        <div class="section-title">住所</div>
+
+        <div class="mb-3">
+            <label class="form-label">郵便番号</label>
+            <input type="text" name="postal_code" class="form-control" placeholder="例：3430025" style="max-width:180px;">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">都道府県</label>
+            <input type="text" name="prefecture" class="form-control" placeholder="例：埼玉県" style="max-width:180px;">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">住所</label>
+            <input type="text" name="address" class="form-control" placeholder="例：越谷市大沢3-6-1">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">建物名・部屋番号</label>
+            <input type="text" name="building" class="form-control" placeholder="例：パルテきたこし1F">
+        </div>
+
+        <div class="section-title">担当医師</div>
+
+        <div id="dentistList">
+            <div class="dentist-row">
+                <input type="text" name="dentists[]" class="form-control" placeholder="例：藤田 融">
+                <button type="button" class="btn-remove-dentist" onclick="removeDentist(this)">×</button>
+            </div>
+        </div>
+        <button type="button" class="btn btn-sm btn-outline-secondary mt-1" onclick="addDentist()">＋ 担当医師を追加</button>
+
+        <div class="section-title">ログイン情報</div>
+
+        <div class="mb-3">
+            <label class="form-label">メールアドレス <span class="text-danger">必須</span></label>
+            <input type="email" name="email" class="form-control" placeholder="例：clinic@example.com" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">パスワード <span class="text-danger">必須</span></label>
+            <input type="password" name="password" class="form-control" placeholder="8文字以上推奨" required>
+        </div>
+
+        <div class="d-flex gap-2 mt-4 mb-5 justify-content-center">
+            <button type="submit" class="btn btn-danger px-4">登録する</button>
+            <a href="{{ url_for('main.clinic_list') }}" class="btn btn-outline-secondary px-4">キャンセル</a>
+        </div>
+
+    </form>
+</div>
+
+<script>
+function updateAccountType() {
+    const isLab = document.querySelector('input[name="account_type"]:checked').value === 'lab';
+    document.getElementById('pageTitle').textContent = isLab ? '新規技工所登録' : '新規医院登録';
+    document.getElementById('sectionInfoTitle').textContent = isLab ? '技工所情報' : '医院情報';
+    document.getElementById('labelSenderName').innerHTML = (isLab ? '技工所名' : '医院名') + ' <span class="text-danger">必須</span>';
+    document.getElementById('inputSenderName').placeholder = isLab ? '例：渋谷歯科技工所' : '例：藤田歯科医院';
+}
+
+function addDentist() {
+    const list = document.getElementById('dentistList');
+    const row = document.createElement('div');
+    row.className = 'dentist-row';
+    row.innerHTML = `
+        <input type="text" name="dentists[]" class="form-control" placeholder="例：担当医師名">
+        <button type="button" class="btn-remove-dentist" onclick="removeDentist(this)">×</button>
+    `;
+    list.appendChild(row);
+}
+
+function removeDentist(btn) {
+    const list = document.getElementById('dentistList');
+    if (list.children.length > 1) {
+        btn.closest('.dentist-row').remove();
+    } else {
+        btn.closest('.dentist-row').querySelector('input').value = '';
+    }
+}
+</script>
+
+{% endblock %}

--- a/templates/main/clinic_view.html
+++ b/templates/main/clinic_view.html
@@ -1,0 +1,134 @@
+{% extends "common/base.html" %}
+{% block title %}{{ clinic.sender_name or clinic.display_name }} | 渋谷歯科技工所{% endblock %}
+{% block content %}
+
+<style>
+    .page-header {
+        background-color: rgb(243, 244, 245);
+        text-align: center;
+        padding: 20px;
+        color: #7c1820;
+        margin-bottom: 20px;
+        margin-top: -2rem;
+    }
+    .info-table th {
+        width: 140px;
+        background-color: #f8f9fa;
+        color: #555;
+        font-weight: normal;
+    }
+    .status-badge {
+        padding: 3px 10px;
+        border-radius: 12px;
+        font-size: 0.85em;
+        font-weight: bold;
+    }
+    .status-受付中 { background-color: #fff3cd; color: #856404; }
+    .status-製作中 { background-color: #cce5ff; color: #004085; }
+    .status-完了   { background-color: #d4edda; color: #155724; }
+</style>
+
+<div class="page-header" style="position: relative;">
+    <h2>{{ clinic.sender_name or clinic.display_name }}</h2>
+    <a href="{{ url_for('users.account', user_id=clinic.user_id) }}"
+       class="btn btn-sm btn-outline-secondary"
+       style="position: absolute; top: 50%; right: 1.5rem; transform: translateY(-50%);">
+        アカウント修正
+    </a>
+</div>
+
+<div class="container-fluid px-4">
+
+    <!-- 医院情報 -->
+    <h5 class="mb-2 fw-bold border-bottom pb-1">
+        {% if clinic.account_type == 'lab' %}技工所情報{% else %}医院情報{% endif %}
+    </h5>
+    <table class="table table-bordered info-table mb-4" style="max-width: 700px;">
+        <tr><th>ID</th><td>{{ clinic.clinic_id or '—' }}</td></tr>
+        <tr>
+            <th>種別</th>
+            <td>
+                {% if clinic.account_type == 'lab' %}
+                <span style="color:#155724; background-color:#d4edda; border-radius:4px; padding:2px 8px; font-size:0.85em;">歯科技工所（DL）</span>
+                {% else %}
+                <span style="color:#004085; background-color:#cce5ff; border-radius:4px; padding:2px 8px; font-size:0.85em;">歯科医院</span>
+                {% endif %}
+            </td>
+        </tr>
+        <tr><th>{% if clinic.account_type == 'lab' %}技工所名{% else %}医院名{% endif %}</th><td class="fw-bold">{{ clinic.sender_name or clinic.display_name }}</td></tr>
+        <tr><th>担当者</th><td>{{ clinic.full_name or '—' }}</td></tr>
+        <tr><th>メール</th><td><a href="mailto:{{ clinic.email }}">{{ clinic.email }}</a></td></tr>
+        <tr><th>電話番号</th><td>{{ clinic.phone or '—' }}</td></tr>
+        <tr>
+            <th>所在地</th>
+            <td>
+                {% if clinic.prefecture or clinic.address %}
+                    〒{{ clinic.postal_code or '' }}　{{ clinic.prefecture }}{{ clinic.address }}
+                    {% if clinic.building %}<br>{{ clinic.building }}{% endif %}
+                {% else %}—{% endif %}
+            </td>
+        </tr>
+        <tr>
+            <th>担当医師</th>
+            <td>
+                {% if clinic.dentists %}
+                    {{ clinic.dentists | join('　／　') }}
+                {% else %}—{% endif %}
+            </td>
+        </tr>
+        <tr><th>登録日</th><td>{{ (clinic.created_at or '')[:10] }}</td></tr>
+    </table>
+
+    <!-- 指示書一覧 -->
+    <h5 class="mb-2 fw-bold border-bottom pb-1">指示書履歴　<small class="text-muted fw-normal">{{ prescriptions | length }} 件</small></h5>
+
+    {% if prescriptions %}
+    <table class="table table-hover table-bordered align-middle w-100">
+        <thead class="table-dark">
+            <tr>
+                <th style="width: 1%; white-space: nowrap;">受付番号</th>
+                <th style="width: 1%; white-space: nowrap;">送信日時</th>
+                <th style="width: 110px; white-space: nowrap;">担当医</th>
+                <th style="width: 160px;">患者名</th>
+                <th style="width: 160px;">セット希望日</th>
+                <th style="width: 300px; min-width: 300px;">製作物</th>
+                <th>状態</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for p in prescriptions %}
+            <tr style="cursor: pointer;" onclick="location.href='{{ url_for('main.prescription_view', prescription_id=p.prescription_id) }}'">
+                <td style="white-space: nowrap; color: #7c1820; font-weight: bold;">No.{{ p.prescription_id }}</td>
+                <td style="white-space: nowrap;">{{ p.created_at[:10] }}</td>
+                <td>{{ p.user_name }}</td>
+                <td>{{ p.patient_name }}{% if p.patient_name_kana %}　{{ p.patient_name_kana }}{% endif %}</td>
+                <td style="white-space: nowrap;">{{ p.appointment_date }} {{ p.appointment_hour }}時</td>
+                <td>
+                    <div style="display:flex; justify-content:space-between; align-items:center; gap:8px;">
+                        <span>{{ p.project_type }}</span>
+                        {% if p.s3_keys %}
+                            {% if p.s3_keys | length == 1 %}
+                            <a href="{{ p.s3_keys[0] }}" onclick="event.stopPropagation();" class="btn btn-sm btn-outline-primary" style="font-size:0.75em; padding:1px 8px; white-space:nowrap;">DL</a>
+                            {% else %}
+                            <a href="{{ url_for('main.prescription_view', prescription_id=p.prescription_id) }}" onclick="event.stopPropagation();" class="btn btn-sm btn-outline-primary" style="font-size:0.75em; padding:1px 8px; white-space:nowrap;">DL ({{ p.s3_keys | length }}件)</a>
+                            {% endif %}
+                        {% endif %}
+                    </div>
+                </td>
+                <td><span class="status-badge status-{{ p.status }}">{{ p.status }}</span></td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <div class="alert alert-info text-center">まだ指示書はありません。</div>
+    {% endif %}
+
+    <div class="text-center mt-4 mb-4">
+        <a href="{{ url_for('main.clinic_list') }}" class="btn btn-outline-secondary">一覧に戻る</a>
+    </div>
+
+</div>
+
+{% endblock %}

--- a/templates/main/index.html
+++ b/templates/main/index.html
@@ -197,7 +197,15 @@ a:active { color: #b22222; text-decoration: none; }
       <div class="japanese-text">渋谷歯科技工所</div>
       <div class="english-text">SHIBUYA Dental Laboratory</div>
     </div>
-</section> 
+</section>
+
+{% if current_user.is_authenticated %}
+<a href="{{ url_for('main.clinic_dashboard') }}" class="text-decoration-none">
+  <div class="alert alert-warning text-center shadow-sm" style="cursor: pointer; font-size: 1.5rem; font-weight: bold; margin-top: 1rem; margin-bottom: 0;">
+    Web歯科技工指示書
+  </div>
+</a>
+{% endif %}
 
 <!-- 連絡先情報 -->
 <h2>〒343-0845 埼玉県越谷市南越谷4-9-6 新越谷プラザビル203</h2>
@@ -208,14 +216,6 @@ a:active { color: #b22222; text-decoration: none; }
     <a href="https://line.me/ti/p/9KRzw2ndvX" target="_blank" rel="noopener noreferrer" class="btn" style="background-color: #00B900; color: white;"><b>LINEで連絡</b></a>
     <a href="{{ url_for('main.recruit') }}" class="btn btn-warning fw-bold">求人情報：一緒に働いてみませんか？</a>
 </div>         
-
-{% if current_user.is_authenticated %}
-<a href="{{ url_for('main.clinic_dashboard') }}" class="text-decoration-none">
-  <div class="alert alert-warning text-center shadow-sm" style="cursor: pointer; font-size: 1.5rem; font-weight: bold;">
-    Web歯科技工指示書
-  </div>
-</a>
-{% endif %}
 
 <!-- データ送信リンク -->
 <a href="{{ url_for('main.meziro_upload_index') }}" class="text-decoration-none">

--- a/templates/main/meziro_upload_index.html
+++ b/templates/main/meziro_upload_index.html
@@ -361,7 +361,7 @@
             value="{{ sender_name }}" {% if sender_name %}readonly{% endif %} required>
     </div>
     <div class="mb-2">
-        <label for="userName" class="form-label">担当歯科医師</label>
+        <label for="userName" class="form-label">担当</label>
         {% if dentists %}
         <select id="userName" class="form-control" required>
             <option value="" disabled selected>担当医を選択してください</option>
@@ -383,8 +383,20 @@
 
     <!-- 患者名 -->
 <div class="mb-2">
-    <label for="PatientName" class="form-label">患者名</label>
-    <input type="PatientName" id="PatientName" class="form-control" placeholder="患者名を入力してください" required>
+    <label class="form-label">患者名 <span class="text-danger">必須</span></label>
+    <div class="d-flex gap-2">
+        <input type="text" id="PatientLastName" class="form-control" placeholder="姓" required>
+        <input type="text" id="PatientFirstName" class="form-control" placeholder="名" required>
+    </div>
+</div>
+
+<!-- 患者名フリガナ -->
+<div class="mb-2">
+    <label class="form-label">フリガナ</label>
+    <div class="d-flex gap-2">
+        <input type="text" id="PatientLastNameKana" class="form-control" placeholder="セイ">
+        <input type="text" id="PatientFirstNameKana" class="form-control" placeholder="メイ">
+    </div>
 </div>
 
 <!-- セット希望日時 -->
@@ -426,124 +438,102 @@
     <label for="projectType" class="form-label">製作物</label>
     <select id="projectType" class="form-control" required>
         <option value="" disabled selected>製作物の種類を選択してください</option>
-        <option value="replica">自家歯牙移植用レプリカ(造影剤無)</option>
-        <option value="replica-contrast">自家歯牙移植用レプリカ(造影剤有)</option>
-        <option value="Zirconia_Gradation">ジルコニアグラデーションクラウン</option>
-        <option value="milling_CADCAM">ミリング-CAD/CAM冠</option>
-        <option value="milling_PEEK">ミリング-PEEK冠</option>
-        <option value="milling_Zirconia">ミリング-ジルコニア</option>        
-        <option value="other">その他</option>
+        <optgroup label="── 歯科医院 ──">
+            <option value="replica">自家歯牙移植用レプリカ(造影剤無)</option>
+            <option value="replica-contrast">自家歯牙移植用レプリカ(造影剤有)</option>
+            <option value="Zirconia_Gradation">ジルコニアグラデーションクラウン</option>
+            <option value="other">その他</option>
+        </optgroup>
+        <optgroup label="── 歯科技工所 ──">
+            <option value="milling_CADCAM">ミリング-CAD/CAM冠</option>
+            <option value="milling_CADCAM_Inlay">ミリング-CAD/CAM Inlay</option>
+            <option value="milling_CADCAM_Bridge">ミリング-CAD/CAM ブリッジ</option>
+            <option value="milling_PEEK">ミリング-PEEK冠</option>
+            <option value="milling_Zirconia">ミリング-ジルコニア</option>
+        </optgroup>
     </select>
 </div>  
 
 
 <!-- 部位選択セクション -->
 <div class="mb-2">
-    <label for="teethSelection" class="form-label">部位 <span class="text-danger">必須</span></label>
-       
-        
-        <!-- 上顎の歯 -->
-        <div style="display: table; width: 100%; border-collapse: collapse; margin-top: 10px;">
-            <div style="display: table-row;">
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">8</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">7</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">6</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">5</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">4</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">3</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">2</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">1</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">1</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">2</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">3</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">4</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">5</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">6</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">7</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">8</div>
-            </div>
-            <div style="display: table-row;">
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="18" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="17" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="16" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="15" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="14" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="13" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="12" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="11" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="21" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="22" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="23" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="24" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="25" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="26" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="27" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="28" style="transform: scale(1.2);"></div>
-            </div>
-        </div>
-        
-        <!-- 下顎の歯 -->
-        <div style="display: table; width: 100%; border-collapse: collapse; margin-top: 5px;">
-            <div style="display: table-row;">
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="48" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="47" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="46" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="45" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="44" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="43" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="42" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="41" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="31" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="32" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="33" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="34" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="35" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="36" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="37" style="transform: scale(1.2);"></div>
-                <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;"><input type="checkbox" name="teeth[]" value="38" style="transform: scale(1.2);"></div>
-            </div>
-            <div style="display: table-row;">
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">8</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">7</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">6</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">5</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">4</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">3</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">2</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">1</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">1</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">2</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">3</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">4</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">5</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">6</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">7</div>
-                <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">8</div>
-            </div>
-        </div>
+    <label class="form-label">部位 <span class="text-danger">必須</span></label>
 
-        <div style="border: 1px solid #ddd; padding: 10px; border-radius: 4px;">
-        <div style="margin-bottom: 5px;">
-                <label style="margin-right: 15px;">
-                    <input type="radio" name="crown_type" value="その他" checked> その他
-                </label>
-                <label style="margin-right: 15px;">
-                    <input type="radio" name="crown_type" value="単冠"> 単冠
-                </label>
-                <label style="margin-right: 15px;">
-                    <input type="radio" name="crown_type" value="連冠"> 連冠
-                </label>
-                <label>
-                    <input type="radio" name="crown_type" value="ブリッジ"> ブリッジ
-                </label>
-            </div>
+    <!-- クラウン種別 -->
+    <div style="border: 1px solid #ddd; padding: 10px; border-radius: 4px; margin-bottom: 8px;">
+        <label style="margin-right: 15px;"><input type="radio" name="crown_type" value="単冠" checked> 単冠</label>
+        <label style="margin-right: 15px;"><input type="radio" name="crown_type" value="連冠"> 連冠</label>
+        <label style="margin-right: 15px;"><input type="radio" name="crown_type" value="ブリッジ"> ブリッジ</label>
+        <label><input type="radio" name="crown_type" value="その他"> その他</label>
+    </div>
+
+    <!-- 凡例 -->
+    <div style="display: flex; gap: 12px; margin-bottom: 6px; font-size: 12px; align-items: center;">
+        <span>クリックで切替：</span>
+        <span style="display:inline-flex;align-items:center;gap:4px;"><span class="tooth-demo tooth-abutment-demo">支</span> 支台歯</span>
+        <span style="display:inline-flex;align-items:center;gap:4px;"><span class="tooth-demo tooth-missing-demo">✕</span> 欠損部</span>
+        <span style="display:inline-flex;align-items:center;gap:4px;"><span class="tooth-demo tooth-fabrication-demo"><span class="tooth-fab-circle"></span></span> 製作部(レプリカ、ガイド)</span>
+    </div>
+
+    <!-- 上顎 -->
+    <div style="display: table; width: 100%; border-collapse: collapse; margin-top: 4px;">
+        <div style="display: table-row;">
+            {% for n in [8,7,6,5,4,3,2,1,1,2,3,4,5,6,7,8] %}
+            <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">{{ n }}</div>
+            {% endfor %}
         </div>
+        <div style="display: table-row;">
+            {% for v in [18,17,16,15,14,13,12,11,21,22,23,24,25,26,27,28] %}
+            <div class="tooth-cell" data-value="{{ v }}" data-state="0" onclick="cycleToothState(this)"
+                 style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px; width: 30px; cursor: pointer; user-select: none; font-size: 11px; font-weight: bold; vertical-align: middle;"></div>
+            {% endfor %}
+        </div>
+    </div>
+
+    <!-- 下顎 -->
+    <div style="display: table; width: 100%; border-collapse: collapse; margin-top: 5px;">
+        <div style="display: table-row;">
+            {% for v in [48,47,46,45,44,43,42,41,31,32,33,34,35,36,37,38] %}
+            <div class="tooth-cell" data-value="{{ v }}" data-state="0" onclick="cycleToothState(this)"
+                 style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px; width: 30px; cursor: pointer; user-select: none; font-size: 11px; font-weight: bold; vertical-align: middle;"></div>
+            {% endfor %}
+        </div>
+        <div style="display: table-row;">
+            {% for n in [8,7,6,5,4,3,2,1,1,2,3,4,5,6,7,8] %}
+            <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">{{ n }}</div>
+            {% endfor %}
+        </div>
+    </div>
+
+    <style>
+    .tooth-cell[data-state="1"] { background-color: #cce5ff; color: #004085; }
+    .tooth-cell[data-state="2"] { background-color: #e9ecef; color: #6c757d; }
+    .tooth-cell[data-state="3"] { background-color: #ffe0b2; }
+    .tooth-fab-circle { display: inline-block; width: 16px; height: 16px; border: 3px solid #dc3545; border-radius: 50%; vertical-align: middle; }
+    .tooth-demo { display: inline-block; width: 22px; height: 22px; line-height: 22px; text-align: center; font-size: 11px; font-weight: bold; border: 1px solid #ddd; border-radius: 2px; }
+    .tooth-abutment-demo    { background-color: #cce5ff; color: #004085; }
+    .tooth-missing-demo     { background-color: #e9ecef; color: #6c757d; }
+    .tooth-fabrication-demo { background-color: #ffe0b2; display: inline-flex; align-items: center; justify-content: center; }
+    </style>
+    <script>
+    function cycleToothState(el) {
+        const next = (parseInt(el.dataset.state || 0) + 1) % 4;
+        el.dataset.state = next;
+        const labels = ['', '支', '✕', '<span class="tooth-fab-circle"></span>'];
+        el.innerHTML = labels[next];
+    }
+    </script>
         
         <!-- シェード選択 -->
         <div style="margin-top: 15px;">
-            <label for="shade" style="display: block; margin-bottom: 5px;">シェード</label>
+            <div style="display: flex; align-items: center; justify-content: center; gap: 16px; margin-top: 10px; margin-bottom: 6px; flex-wrap: wrap;">
+                <label style="margin: 0;">シェード</label>
+                <label style="margin: 0; font-weight: normal;"><input type="radio" name="shade_system" value="classical" checked onchange="updateShadeOptions()"> VITAクラシカル</label>
+                <label style="margin: 0; font-weight: normal;"><input type="radio" name="shade_system" value="3dmaster" onchange="updateShadeOptions()"> VITA 3D-MASTER</label>
+            </div>
             <select id="shade" name="shade" class="form-control">
                 <option value="">指定なし(指定不要なケース)</option>
+                <option value="画像有り">画像有り</option>
                 <option value="A1">A1</option>
                 <option value="A2">A2</option>
                 <option value="A3">A3</option>
@@ -557,11 +547,47 @@
                 <option value="C2">C2</option>
                 <option value="C3">C3</option>
                 <option value="C4">C4</option>
+                <option value="D1">D1</option>
                 <option value="D2">D2</option>
                 <option value="D3">D3</option>
                 <option value="D4">D4</option>
             </select>
         </div>
+
+        <script>
+        const shadeOptions = {
+            classical: [
+                ['', '指定なし(指定不要なケース)'],
+                ['画像有り', '画像有り'],
+                ...['A1','A2','A3','A3.5','A4','B1','B2','B3','B4','C1','C2','C3','C4','D1','D2','D3','D4'].map(s => [s, s])
+            ],
+            '3dmaster': [
+                ['', '指定なし(指定不要なケース)'],
+                ['画像有り', '画像有り'],
+                ...['0M1','0M2','0M3',
+                    '1M1','1M2',
+                    '2L1.5','2L2.5','2M1','2M2','2M3','2R1.5','2R2.5',
+                    '3L1.5','3L2.5','3M1','3M2','3M3','3R1.5','3R2.5',
+                    '4L1.5','4L2.5','4M1','4M2','4M3','4R1.5','4R2.5',
+                    '5M1','5M2','5M3'
+                ].map(s => [s, s])
+            ]
+        };
+
+        function updateShadeOptions() {
+            const system = document.querySelector('input[name="shade_system"]:checked').value;
+            const select = document.getElementById('shade');
+            const current = select.value;
+            select.innerHTML = '';
+            shadeOptions[system].forEach(([val, label]) => {
+                const opt = document.createElement('option');
+                opt.value = val;
+                opt.textContent = label;
+                if (val === current) opt.selected = true;
+                select.appendChild(opt);
+            });
+        }
+        </script>
     </div>
 </div>
 

--- a/templates/main/prescription.html
+++ b/templates/main/prescription.html
@@ -132,6 +132,11 @@
         border-radius: 4px;
         background-color: #f8f9fa;
         margin-top: 5px;
+        transition: border-color 0.2s, background-color 0.2s;
+    }
+    .image-upload-area.drag-over {
+        border-color: #7c1820;
+        background-color: #fff0f0;
     }
     .image-thumbnails {
         display: flex;
@@ -186,8 +191,10 @@
     a:link, a:visited, a:hover, a:active { color: #8b0000; text-decoration: none; }
 </style>
 
-<div class="page-header">
+<div class="page-header" style="position: relative;">
     <h1>Web歯科技工指示書</h1>
+    <a href="{{ url_for('main.clinic_dashboard') }}" class="btn btn-outline-secondary btn-sm"
+       style="position: absolute; right: 16px; top: 50%; transform: translateY(-50%);">医院トップへ</a>
 </div>
 
 <!-- ログイン医院情報の表示 -->
@@ -199,46 +206,53 @@
 <div class="input-zone" id="input-zone">
     <div class="mt-3 mb-2">
 
-        <!-- 歯科医院名（読み取り専用・メールアドレス併記） -->
-        <div class="mb-2">
-            <label class="form-label">事業者名</label>
-            <input type="text" id="businessName" class="form-control" value="{{ sender_name }}　ID:{{ user_email }}" readonly>
-        </div>
 
         <!-- メールアドレス（非表示・送信用） -->
         <input type="hidden" id="userEmail" value="{{ user_email }}">
 
         <!-- 担当歯科医師（プルダウン or テキスト） -->
         <div class="mb-2">
-            <label for="userName" class="form-label">担当歯科医師 <span class="text-danger">必須</span></label>
+            <label for="userName" class="form-label">担当 <span class="text-danger">必須</span></label>
             {% if dentists %}
             <select id="userName" class="form-control" required>
-                <option value="" disabled selected>担当医を選択してください</option>
+                <option value="" disabled {% if not default_user_name %}selected{% endif %}>担当医を選択してください</option>
                 {% for d in dentists %}
-                <option value="{{ d }}">{{ d }}</option>
+                <option value="{{ d }}" {% if d == default_user_name %}selected{% endif %}>{{ d }}</option>
                 {% endfor %}
             </select>
             {% else %}
-            <input type="text" id="userName" class="form-control" placeholder="担当医・担当者名を入力してください" required>
+            <input type="text" id="userName" class="form-control" placeholder="担当医・担当者名を入力してください" value="{{ default_user_name }}" required>
             {% endif %}
         </div>
 
         <!-- カルテ番号 -->
         <div class="mb-2">
-            <label for="ChartNumber" class="form-label">カルテ番号</label>
-            <input type="text" id="ChartNumber" class="form-control" placeholder="カルテ番号を入力してください">
+            <div class="d-flex align-items-center gap-3 mb-1">
+                <label for="ChartNumber" class="form-label mb-0">カルテ番号 <span class="text-danger">必須</span></label>
+                <label class="form-check-label d-flex align-items-center gap-1" style="font-weight: normal; cursor: pointer;">
+                    <input type="checkbox" id="chartUnknown" class="form-check-input mt-0" onchange="toggleChartUnknown(this)">
+                    不明
+                </label>
+            </div>
+            <input type="text" id="ChartNumber" class="form-control" placeholder="カルテ番号を入力してください" required>
         </div>
 
         <!-- 患者名 -->
         <div class="mb-2">
-            <label for="PatientName" class="form-label">患者名 <span class="text-danger">必須</span></label>
-            <input type="text" id="PatientName" class="form-control" placeholder="患者名を入力してください" required>
+            <label class="form-label">患者名 <span class="text-danger">必須</span></label>
+            <div class="d-flex gap-2">
+                <input type="text" id="PatientLastName" class="form-control" placeholder="姓" required>
+                <input type="text" id="PatientFirstName" class="form-control" placeholder="名" required>
+            </div>
         </div>
 
         <!-- 患者名フリガナ -->
         <div class="mb-2">
-            <label for="PatientNameKana" class="form-label">フリガナ</label>
-            <input type="text" id="PatientNameKana" class="form-control" placeholder="カタカナで入力してください">
+            <label class="form-label">フリガナ</label>
+            <div class="d-flex gap-2">
+                <input type="text" id="PatientLastNameKana" class="form-control" placeholder="セイ">
+                <input type="text" id="PatientFirstNameKana" class="form-control" placeholder="メイ">
+            </div>
         </div>
 
         <!-- セット希望日時 -->
@@ -271,13 +285,19 @@
             <label for="projectType" class="form-label">製作物 <span class="text-danger">必須</span></label>
             <select id="projectType" class="form-control" required>
                 <option value="" disabled selected>製作物の種類を選択してください</option>
-                <option value="replica">自家歯牙移植用レプリカ(造影剤無)</option>
-                <option value="replica-contrast">自家歯牙移植用レプリカ(造影剤有)</option>
-                <option value="Zirconia_Gradation">ジルコニアグラデーションクラウン</option>
-                <option value="milling_CADCAM">ミリング-CAD/CAM冠</option>
-                <option value="milling_PEEK">ミリング-PEEK冠</option>
-                <option value="milling_Zirconia">ミリング-ジルコニア</option>
-                <option value="other">その他</option>
+                <optgroup label="── 歯科医院 ──">
+                    <option value="replica">自家歯牙移植用レプリカ(造影剤無)</option>
+                    <option value="replica-contrast">自家歯牙移植用レプリカ(造影剤有)</option>
+                    <option value="Zirconia_Gradation">ジルコニアグラデーションクラウン</option>
+                    <option value="other">その他</option>
+                </optgroup>
+                <optgroup label="── 歯科技工所 ──">
+                    <option value="milling_CADCAM">ミリング-CAD/CAM冠</option>
+                    <option value="milling_CADCAM_Inlay">ミリング-CAD/CAM Inlay</option>
+                    <option value="milling_CADCAM_Bridge">ミリング-CAD/CAM ブリッジ</option>
+                    <option value="milling_PEEK">ミリング-PEEK冠</option>
+                    <option value="milling_Zirconia">ミリング-ジルコニア</option>
+                </optgroup>
             </select>
         </div>
 
@@ -285,8 +305,24 @@
         <div class="mb-2">
             <label class="form-label">部位 <span class="text-danger">必須</span></label>
 
+            <!-- クラウン種別 -->
+            <div style="border: 1px solid #ddd; padding: 10px; border-radius: 4px; margin-bottom: 8px;">
+                <label style="margin-right: 15px;"><input type="radio" name="crown_type" value="単冠" checked> 単冠</label>
+                <label style="margin-right: 15px;"><input type="radio" name="crown_type" value="連冠"> 連冠</label>
+                <label style="margin-right: 15px;"><input type="radio" name="crown_type" value="ブリッジ"> ブリッジ</label>
+                <label><input type="radio" name="crown_type" value="その他"> その他</label>
+            </div>
+
+            <!-- 凡例 -->
+            <div style="display: flex; gap: 12px; margin-bottom: 6px; font-size: 12px; align-items: center;">
+                <span>クリックで切替：</span>
+                <span style="display:inline-flex;align-items:center;gap:4px;"><span class="tooth-demo tooth-abutment-demo">支</span> 支台歯</span>
+                <span style="display:inline-flex;align-items:center;gap:4px;"><span class="tooth-demo tooth-missing-demo">✕</span> 欠損部</span>
+                <span style="display:inline-flex;align-items:center;gap:4px;"><span class="tooth-demo tooth-fabrication-demo"><span class="tooth-fab-circle"></span></span> 製作部(レプリカ、ガイド)</span>
+            </div>
+
             <!-- 上顎 -->
-            <div style="display: table; width: 100%; border-collapse: collapse; margin-top: 10px;">
+            <div style="display: table; width: 100%; border-collapse: collapse; margin-top: 4px;">
                 <div style="display: table-row;">
                     {% for n in [8,7,6,5,4,3,2,1,1,2,3,4,5,6,7,8] %}
                     <div style="display: table-cell; text-align: center; background-color: #f8d7da; border: 1px solid #ddd; width: 30px;">{{ n }}</div>
@@ -294,9 +330,8 @@
                 </div>
                 <div style="display: table-row;">
                     {% for v in [18,17,16,15,14,13,12,11,21,22,23,24,25,26,27,28] %}
-                    <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;">
-                        <input type="checkbox" name="teeth[]" value="{{ v }}" style="transform: scale(1.2);">
-                    </div>
+                    <div class="tooth-cell" data-value="{{ v }}" data-state="0" onclick="cycleToothState(this)"
+                         style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px; width: 30px; cursor: pointer; user-select: none; font-size: 11px; font-weight: bold; vertical-align: middle;"></div>
                     {% endfor %}
                 </div>
             </div>
@@ -305,9 +340,8 @@
             <div style="display: table; width: 100%; border-collapse: collapse; margin-top: 5px;">
                 <div style="display: table-row;">
                     {% for v in [48,47,46,45,44,43,42,41,31,32,33,34,35,36,37,38] %}
-                    <div style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px;">
-                        <input type="checkbox" name="teeth[]" value="{{ v }}" style="transform: scale(1.2);">
-                    </div>
+                    <div class="tooth-cell" data-value="{{ v }}" data-state="0" onclick="cycleToothState(this)"
+                         style="display: table-cell; text-align: center; border: 1px solid #ddd; height: 30px; width: 30px; cursor: pointer; user-select: none; font-size: 11px; font-weight: bold; vertical-align: middle;"></div>
                     {% endfor %}
                 </div>
                 <div style="display: table-row;">
@@ -317,25 +351,76 @@
                 </div>
             </div>
 
-            <!-- クラウン種別 -->
-            <div style="border: 1px solid #ddd; padding: 10px; border-radius: 4px; margin-top: 8px;">
-                <label style="margin-right: 15px;"><input type="radio" name="crown_type" value="単冠" checked> 単冠</label>
-                <label style="margin-right: 15px;"><input type="radio" name="crown_type" value="連冠"> 連冠</label>
-                <label style="margin-right: 15px;"><input type="radio" name="crown_type" value="ブリッジ"> ブリッジ</label>
-                <label><input type="radio" name="crown_type" value="その他"> その他</label>
-            </div>
+            <style>
+            .tooth-cell[data-state="1"] { background-color: #cce5ff; color: #004085; }
+            .tooth-cell[data-state="2"] { background-color: #e9ecef; color: #6c757d; }
+            .tooth-cell[data-state="3"] { background-color: #ffe0b2; }
+            .tooth-fab-circle { display: inline-block; width: 16px; height: 16px; border: 3px solid #dc3545; border-radius: 50%; vertical-align: middle; }
+            .tooth-demo { display: inline-block; width: 22px; height: 22px; line-height: 22px; text-align: center; font-size: 11px; font-weight: bold; border: 1px solid #ddd; border-radius: 2px; }
+            .tooth-abutment-demo    { background-color: #cce5ff; color: #004085; }
+            .tooth-missing-demo     { background-color: #e9ecef; color: #6c757d; }
+            .tooth-fabrication-demo { background-color: #ffe0b2; }
+            </style>
+            <script>
+            function cycleToothState(el) {
+                const next = (parseInt(el.dataset.state || 0) + 1) % 4;
+                el.dataset.state = next;
+                const labels = ['', '支', '✕', '<span class="tooth-fab-circle"></span>'];
+                el.innerHTML = labels[next];
+            }
+            </script>
 
             <!-- シェード -->
             <div style="margin-top: 15px;">
-                <label for="shade" style="display: block; margin-bottom: 5px;">シェード</label>
+                <div style="display: flex; align-items: center; justify-content: center; gap: 16px; margin-top: 10px; margin-bottom: 6px; flex-wrap: wrap;">
+                    <label style="margin: 0;">シェード</label>
+                    <label style="margin: 0; font-weight: normal;"><input type="radio" name="shade_system" value="classical" checked onchange="updateShadeOptions()"> VITAクラシカル</label>
+                    <label style="margin: 0; font-weight: normal;"><input type="radio" name="shade_system" value="3dmaster" onchange="updateShadeOptions()"> VITA 3D-MASTER</label>
+                </div>
+
                 <select id="shade" name="shade" class="form-control">
                     <option value="">指定なし(指定不要なケース)</option>
                     <option value="画像有り">画像有り</option>
-                    {% for s in ['A1','A2','A3','A3.5','A4','B1','B2','B3','B4','C1','C2','C3','C4','D2','D3','D4'] %}
+                    {% for s in ['A1','A2','A3','A3.5','A4','B1','B2','B3','B4','C1','C2','C3','C4','D1','D2','D3','D4'] %}
                     <option value="{{ s }}">{{ s }}</option>
                     {% endfor %}
                 </select>
             </div>
+
+            <script>
+            const shadeOptions = {
+                classical: [
+                    ['', '指定なし(指定不要なケース)'],
+                    ['画像有り', '画像有り'],
+                    ...['A1','A2','A3','A3.5','A4','B1','B2','B3','B4','C1','C2','C3','C4','D1','D2','D3','D4'].map(s => [s, s])
+                ],
+                '3dmaster': [
+                    ['', '指定なし(指定不要なケース)'],
+                    ['画像有り', '画像有り'],
+                    ...['0M1','0M2','0M3',
+                        '1M1','1M2',
+                        '2L1.5','2L2.5','2M1','2M2','2M3','2R1.5','2R2.5',
+                        '3L1.5','3L2.5','3M1','3M2','3M3','3R1.5','3R2.5',
+                        '4L1.5','4L2.5','4M1','4M2','4M3','4R1.5','4R2.5',
+                        '5M1','5M2','5M3'
+                    ].map(s => [s, s])
+                ]
+            };
+
+            function updateShadeOptions() {
+                const system = document.querySelector('input[name="shade_system"]:checked').value;
+                const select = document.getElementById('shade');
+                const current = select.value;
+                select.innerHTML = '';
+                shadeOptions[system].forEach(([val, label]) => {
+                    const opt = document.createElement('option');
+                    opt.value = val;
+                    opt.textContent = label;
+                    if (val === current) opt.selected = true;
+                    select.appendChild(opt);
+                });
+            }
+            </script>
         </div>
 
     </div>
@@ -352,16 +437,16 @@
 <div class="mb-2" style="max-width: 800px; margin: 10px auto 0 auto;">
     <label class="form-label">画像添付</label>
     <div id="imageUploadArea" class="image-upload-area">
-        <input type="file" id="imageInput" accept="image/*" style="display: none;">
+        <input type="file" id="imageInput" accept="image/*" style="display: none;" multiple>
         <button type="button" onclick="document.getElementById('imageInput').click()">+ 画像を追加</button>
-        <p style="margin: 6px 0 0; font-size: 0.85em; color: #666;">クリックして画像を1枚選択（繰り返し追加できます）</p>
+        <p style="margin: 6px 0 0; font-size: 0.85em; color: #666;">クリックまたは画像をここにドラッグ＆ドロップ</p>
     </div>
     <div id="imageThumbnails" class="image-thumbnails"></div>
 </div>
 
 <!-- ドロップゾーン -->
 <div class="drop-zone" id="dropZone">
-    <p>シェード画像、参考データがあれば添付してください。<br>ここにファイル・フォルダをドラッグ＆ドロップするか、クリックして選択してください</p>
+    <p>画像以外のDICOM、STL、参考データなどがあれば添付してください。<br>ここにファイル・フォルダをドラッグ＆ドロップするか、クリックして選択してください</p>
     <p style="font-size: 0.9em; color: #666;">
         最大ファイルサイズ: 2GB<br>
         対応ファイル: すべて

--- a/templates/main/prescription.html
+++ b/templates/main/prescription.html
@@ -125,6 +125,50 @@
         line-height: 20px;
         color: white;
     }
+    .image-upload-area {
+        border: 2px dashed #ccc;
+        padding: 15px;
+        text-align: center;
+        border-radius: 4px;
+        background-color: #f8f9fa;
+        margin-top: 5px;
+    }
+    .image-thumbnails {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-top: 10px;
+        min-height: 0;
+    }
+    .image-thumb-item {
+        position: relative;
+        width: 100px;
+        height: 100px;
+    }
+    .image-thumb-item img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: 4px;
+        border: 1px solid #ddd;
+        cursor: pointer;
+    }
+    .image-thumb-remove {
+        position: absolute;
+        top: -6px;
+        right: -6px;
+        background: #dc3545;
+        color: white;
+        border: none;
+        border-radius: 50%;
+        width: 20px;
+        height: 20px;
+        cursor: pointer;
+        font-size: 13px;
+        line-height: 20px;
+        text-align: center;
+        padding: 0;
+    }
     .button-group { margin-top: 15px; }
     button {
         padding: 8px 16px;
@@ -182,7 +226,7 @@
         <!-- カルテ番号 -->
         <div class="mb-2">
             <label for="ChartNumber" class="form-label">カルテ番号</label>
-            <input type="text" id="ChartNumber" class="form-control" placeholder="カルテ番号を入力してください（任意）">
+            <input type="text" id="ChartNumber" class="form-control" placeholder="カルテ番号を入力してください">
         </div>
 
         <!-- 患者名 -->
@@ -302,6 +346,17 @@
     <label for="userMessage" class="form-label">備考（指示の詳細）</label>
     <textarea id="userMessage" class="form-control" rows="4"
         placeholder="指示の詳細、備考など入力してください。"></textarea>
+</div>
+
+<!-- 画像添付 -->
+<div class="mb-2" style="max-width: 800px; margin: 10px auto 0 auto;">
+    <label class="form-label">画像添付</label>
+    <div id="imageUploadArea" class="image-upload-area">
+        <input type="file" id="imageInput" accept="image/*" style="display: none;">
+        <button type="button" onclick="document.getElementById('imageInput').click()">+ 画像を追加</button>
+        <p style="margin: 6px 0 0; font-size: 0.85em; color: #666;">クリックして画像を1枚選択（繰り返し追加できます）</p>
+    </div>
+    <div id="imageThumbnails" class="image-thumbnails"></div>
 </div>
 
 <!-- ドロップゾーン -->

--- a/templates/main/prescription_list.html
+++ b/templates/main/prescription_list.html
@@ -21,18 +21,22 @@
     .status-完了     { background-color: #d4edda; color: #155724; }
 </style>
 
-<div class="page-header">
+<div class="page-header" style="position: relative;">
     <h2>指示書一覧</h2>
+    {% if not current_user.is_administrator %}
+    <a href="{{ url_for('main.clinic_dashboard') }}" class="btn btn-outline-secondary btn-sm"
+       style="position: absolute; right: 16px; top: 50%; transform: translateY(-50%);">医院トップへ</a>
+    {% endif %}
 </div>
 
-<div class="container" style="max-width: 1000px;">
+<div class="container-fluid px-4">
 
     {% if prescriptions %}
     <table class="table table-hover table-bordered">
         <thead class="table-dark">
             <tr>
-                <th>受付番号</th>
-                <th>送信日時</th>
+                <th style="width: 1%; white-space: nowrap;">受付番号</th>
+                <th style="width: 1%; white-space: nowrap;">送信日時</th>
                 {% if current_user.is_administrator %}
                 <th>事業者名</th>
                 {% endif %}
@@ -46,21 +50,18 @@
         </thead>
         <tbody>
             {% for p in prescriptions %}
-            <tr>
-                <td>No.{{ p.prescription_id }}</td>
-                <td>{{ p.created_at[:10] }}</td>
+            <tr style="cursor: pointer;" onclick="location.href='{{ url_for('main.prescription_view', prescription_id=p.prescription_id) }}'">
+                <td style="white-space: nowrap; color: #7c1820; font-weight: bold;">No.{{ p.prescription_id }}</td>
+                <td style="white-space: nowrap;">{{ p.created_at[:10] }}</td>
                 {% if current_user.is_administrator %}
                 <td>{{ p.business_name }}</td>
                 {% endif %}
                 <td>{{ p.user_name }}</td>
                 <td>{{ p.patient_name }}{% if p.patient_name_kana %}　{{ p.patient_name_kana }}{% endif %}</td>
-                <td>{{ p.appointment_date }}　{{ p.appointment_hour }}時</td>
+                <td>{{ p.appointment_date }} {{ p.appointment_hour }}時</td>
                 <td>{{ p.project_type }}</td>
                 <td>
                     <span class="status-badge status-{{ p.status }}">{{ p.status }}</span>
-                </td>
-                <td>
-                    <a href="{{ url_for('main.prescription_view', prescription_id=p.prescription_id) }}" target="_blank" class="btn btn-sm btn-outline-secondary">表示</a>
                 </td>
             </tr>
             {% endfor %}

--- a/templates/main/prescription_view.html
+++ b/templates/main/prescription_view.html
@@ -87,15 +87,55 @@
             font-size: 14px;
             cursor: pointer;
         }
+        .back-btn {
+            display: inline-block;
+            margin: 0 auto 20px 0;
+            padding: 6px 20px;
+            background-color: #f8f9fa;
+            color: #333;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            font-size: 13px;
+            cursor: pointer;
+            text-decoration: none;
+        }
+        .btn-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+        }
+        .zip-dl-btn {
+            display: inline-block;
+            padding: 6px 16px;
+            background-color: #17a2b8;
+            color: white !important;
+            border-radius: 4px;
+            font-size: 13px;
+            text-decoration: none;
+        }
+        .zip-dl-btn:hover { background-color: #138496; }
         @media print {
-            .print-btn { display: none; }
+            .print-btn  { display: none; }
+            .back-btn   { display: none; }
+            .btn-row    { display: none; }
+            .zip-dl-btn { display: none; }
             body { padding: 10px 20px; }
         }
     </style>
 </head>
 <body>
 
-<button class="print-btn" onclick="window.print()">印刷 / PDF保存</button>
+<div class="btn-row" style="position: relative;">
+    <div style="display: flex; gap: 8px;">
+        <a class="back-btn" onclick="history.back(); return false;" href="#">← 戻る</a>
+        {% if not current_user.is_administrator %}
+        <a class="back-btn" href="{{ url_for('main.clinic_dashboard') }}">医院トップへ</a>
+        {% endif %}
+    </div>
+    <button class="print-btn" onclick="window.print()"
+            style="position: absolute; left: 50%; transform: translateX(-50%); margin: 0;">印刷 / PDF保存</button>
+</div>
 
 <div class="header">
     <h1>歯科技工指示書</h1>
@@ -110,7 +150,7 @@
 
 <table>
     <tr><th>事業者名</th><td>{{ p.business_name }}</td></tr>
-    <tr><th>担当歯科医師</th><td>{{ p.user_name }}</td></tr>
+    <tr><th>担当</th><td>{{ p.user_name }}</td></tr>
     <tr><th>カルテ番号</th><td>{{ p.chart_number or '―' }}</td></tr>
     <tr><th>患者名</th><td>{{ p.patient_name }}{% if p.patient_name_kana %}　{{ p.patient_name_kana }}{% endif %}</td></tr>
     <tr><th>セット希望日</th><td>{{ p.appointment_date }}　{{ p.appointment_hour }}時</td></tr>
@@ -124,14 +164,102 @@
         <th>対象部位</th>
         <td>
             <div class="teeth-grid">
-                {% for t in p.teeth %}
-                <span class="tooth">{{ t }}</span>
-                {% endfor %}
+                {% if p.teeth_abutment or p.teeth_missing or p.teeth_fabrication %}
+                    {% for t in p.teeth_abutment or [] %}
+                    <span class="tooth" style="background-color:#cce5ff; color:#004085; border-color:#004085;">支 {{ t }}</span>
+                    {% endfor %}
+                    {% for t in p.teeth_missing or [] %}
+                    <span class="tooth" style="background-color:#e9ecef; color:#6c757d; border-color:#aaa;">✕ {{ t }}</span>
+                    {% endfor %}
+                    {% for t in p.teeth_fabrication or [] %}
+                    <span class="tooth" style="background-color:#ffe0b2; border-color:#dc3545; display:inline-flex; align-items:center; gap:3px;">
+                        <span style="display:inline-block; width:10px; height:10px; border:2.5px solid #dc3545; border-radius:50%; flex-shrink:0;"></span>{{ t }}
+                    </span>
+                    {% endfor %}
+                {% else %}
+                    {% for t in p.teeth %}
+                    <span class="tooth">{{ t }}</span>
+                    {% endfor %}
+                {% endif %}
             </div>
         </td>
     </tr>
     <tr><th>備考</th><td style="white-space: pre-wrap;">{{ p.message or '―' }}</td></tr>
 </table>
+
+{% if file_items %}
+<div class="section" style="margin-bottom: 20px;">
+    <div style="font-weight: bold; margin-bottom: 8px; border-bottom: 1px solid #ccc; padding-bottom: 4px;">アップロード済みファイル</div>
+    <div style="display: flex; flex-wrap: wrap; gap: 8px; align-items: center;">
+        {% for fi in file_items %}
+        <div style="display: flex; align-items: center; gap: 6px;">
+            {% if current_user.is_administrator %}
+            <a href="{{ fi.url }}" class="zip-dl-btn">⬇ {{ fi.name }}</a>
+            {% else %}
+            <span style="color: #555; font-size: 13px; padding: 4px 10px; border: 1px solid #ccc; border-radius: 4px;">{{ fi.name }}</span>
+            {% endif %}
+            {% if can_delete %}
+            <button class="delete-file-btn" data-key="{{ fi.key }}" data-type="file"
+                    style="padding: 4px 10px; background: #dc3545; color: white; border: none; border-radius: 4px; font-size: 12px; cursor: pointer;">
+                削除
+            </button>
+            {% endif %}
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% endif %}
+
+{% if image_items %}
+<div class="section" style="margin-bottom: 20px;">
+    <div style="font-weight: bold; margin-bottom: 8px; border-bottom: 1px solid #ccc; padding-bottom: 4px;">添付画像</div>
+    <div style="display: flex; flex-wrap: wrap; gap: 12px;">
+        {% for item in image_items %}
+        <div style="position: relative; display: inline-block;">
+            <a href="{{ item.url }}" target="_blank">
+                <img src="{{ item.url }}" style="max-width: 200px; max-height: 200px; object-fit: cover; border: 1px solid #ddd; border-radius: 4px; cursor: pointer; display: block;">
+            </a>
+            {% if can_delete %}
+            <button class="delete-file-btn" data-key="{{ item.key }}" data-type="image"
+                    style="position: absolute; top: 4px; right: 4px; padding: 2px 8px; background: rgba(220,53,69,0.85); color: white; border: none; border-radius: 3px; font-size: 11px; cursor: pointer;">
+                削除
+            </button>
+            {% endif %}
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% endif %}
+
+<script>
+document.querySelectorAll('.delete-file-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+        if (!confirm('このファイルを削除しますか？この操作は取り消せません。')) return;
+        var key = this.dataset.key;
+        var type = this.dataset.type;
+        var container = this.closest('[style*="position: relative"]') || this.closest('[style*="display: flex"]');
+        var self = this;
+        var formData = new FormData();
+        formData.append('s3_key', key);
+        formData.append('file_type', type);
+        formData.append('csrf_token', '{{ csrf_token() }}');
+        fetch('{{ url_for("main.delete_prescription_file", prescription_id=p.prescription_id) }}', {
+            method: 'POST',
+            body: formData
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.success) {
+                var el = self.closest('div[style*="position: relative"]') || self.parentElement;
+                el.remove();
+            } else {
+                alert('削除に失敗しました: ' + (data.error || '不明なエラー'));
+            }
+        })
+        .catch(function() { alert('通信エラーが発生しました。'); });
+    });
+});
+</script>
 
 <div class="footer">
     渋谷歯科技工所 / shibuya8020.com

--- a/templates/main/recruit.html
+++ b/templates/main/recruit.html
@@ -45,14 +45,11 @@
     "value": {
       "@type": "QuantitativeValue",
       "minValue": 200000,
+      "maxValue": 350000,
       "unitText": "MONTH"
     }
   },
-  "qualifications": "歯科技工士免許",
-  "educationRequirements": {
-    "@type": "EducationalOccupationalCredential",
-    "credentialCategory": "professional license"
-  }
+  "qualifications": "歯科技工士免許をお持ちの方（新卒歓迎）"
 }
 </script>
 {% endblock %}

--- a/templates/users/account.html
+++ b/templates/users/account.html
@@ -39,6 +39,10 @@
 #}
     {% endif %}
 
+    <div class="container my-2" style="max-width: 576px;">
+        <a href="#" onclick="history.back(); return false;" class="btn btn-outline-secondary btn-sm">← 戻る</a>
+    </div>
+
     <section id="user_update">
         <div class="container my-3">
             <div class="row">
@@ -53,7 +57,8 @@
                                     {{ render_field(form.display_name, class="form-control form-control-lg", placeholder="ユーザー名") }}
                                 </div>
                                 <div class="mb-3">
-                                    {{ render_field(form.email, class="form-control form-control-lg", placeholder="メールアドレス") }}
+                                    {{ render_field(form.email, class="form-control form-control-lg", placeholder="メールアドレス", readonly=True) }}
+                                    <div class="text-white-50 small mt-1" style="font-size: 0.8em;">メールアドレスはログインIDです。変更の場合は渋谷歯科技工所までご連絡ください。</div>
                                 </div>
                                 <div class="mb-3">
                                     {{ render_field(form.full_name, placeholder="氏名", class="form-control form-control-lg") }}

--- a/views/main.py
+++ b/views/main.py
@@ -18,7 +18,7 @@ import requests
 from boto3.dynamodb.conditions import Attr
 from dotenv import load_dotenv
 from moviepy import VideoFileClip
-from PIL import Image
+from PIL import Image, ImageOps
 from pytz import timezone as pytz_timezone
 
 # Flask関連
@@ -1156,6 +1156,10 @@ def meziro_upload():
     has_files = bool(files and files[0].filename != '')
     log.info("受信ファイル数: %d", len(files) if has_files else 0)
 
+    images = request.files.getlist('images[]')
+    has_images = bool(images and images[0].filename != '')
+    log.info("受信画像数: %d", len(images) if has_images else 0)
+
     uploaded_urls = []
     numbered_ids  = []
 
@@ -1279,6 +1283,41 @@ def meziro_upload():
             except Exception as e:
                 log.warning("一時ZIP削除失敗: %s err=%s", zip_file_path, e)
 
+        # 画像ファイルの処理（リサイズ → S3保存）
+        image_keys = []
+        if has_images:
+            img_prefix = f"meziro/{id_str}/images/"
+            fmt_map = {'.jpg': 'JPEG', '.jpeg': 'JPEG', '.png': 'PNG', '.gif': 'GIF', '.webp': 'WEBP'}
+            ct_map  = {'JPEG': 'image/jpeg', 'PNG': 'image/png', 'GIF': 'image/gif', 'WEBP': 'image/webp'}
+            for idx, img_file in enumerate(images, start=1):
+                if not img_file or not img_file.filename:
+                    continue
+                try:
+                    raw = Image.open(io.BytesIO(img_file.read()))
+                    pil_img: Image.Image = ImageOps.exif_transpose(raw) or raw  # EXIF回転補正
+                    if pil_img.width > 2000:
+                        new_h = int(pil_img.height * 2000 / pil_img.width)
+                        pil_img = pil_img.resize((2000, new_h), Image.Resampling.LANCZOS)
+                    orig_name = sanitize_filename(img_file.filename)
+                    ext  = os.path.splitext(orig_name)[1].lower()
+                    fmt  = fmt_map.get(ext, 'JPEG')
+                    if fmt == 'JPEG' and pil_img.mode in ('RGBA', 'P', 'LA'):
+                        pil_img = pil_img.convert('RGB')
+                    buf = io.BytesIO()
+                    if fmt == 'JPEG':
+                        pil_img.save(buf, format='JPEG', quality=90)
+                    else:
+                        pil_img.save(buf, format=fmt)
+                    buf.seek(0)
+                    final_w = pil_img.width
+                    s3_img_key = get_unique_filename(bucket_name, f"{img_prefix}{idx:03d}_{orig_name}")
+                    s3.upload_fileobj(buf, bucket_name, s3_img_key,
+                                      ExtraArgs={'ContentType': ct_map.get(fmt, 'image/jpeg')})
+                    image_keys.append(s3_img_key)
+                    log.info("画像S3アップロードOK: key=%s w=%d", s3_img_key, final_w)
+                except Exception as img_err:
+                    log.error("画像処理エラー: filename=%s err=%s", img_file.filename, img_err, exc_info=True)
+
         # メール本文
         url_text = "\n".join(uploaded_urls)
         full_message = f"""ユーザーから以下のメッセージが届きました：
@@ -1378,6 +1417,7 @@ email: shibuya8020@gmail.com
                 "shade":           shade,
                 "message":         message,
                 "s3_keys":         [url_for('main.meziro_download', key=k.split('/meziro/download/')[-1], _external=False) if '/meziro/download/' in k else k for k in uploaded_urls],
+                "image_keys":      image_keys,
                 "status":          "受付中",
                 "created_at":      received_at_str,
                 "updated_at":      received_at_str,

--- a/views/main.py
+++ b/views/main.py
@@ -1027,9 +1027,16 @@ def prescription_list():
     prescriptions_table = current_app.config["PRESCRIPTIONS_TABLE"]
 
     if current_user.is_administrator:
-        # 管理者は全件取得
-        resp = prescriptions_table.scan()
-        items = resp.get("Items", [])
+        # 管理者は全件取得（ページネーション対応）
+        items = []
+        scan_kwargs = {}
+        while True:
+            resp = prescriptions_table.scan(**scan_kwargs)
+            items.extend(resp.get("Items", []))
+            last = resp.get("LastEvaluatedKey")
+            if not last:
+                break
+            scan_kwargs["ExclusiveStartKey"] = last
     else:
         # 一般ユーザーは自分の指示書のみ
         from boto3.dynamodb.conditions import Key
@@ -1057,13 +1064,225 @@ def prescription_view(prescription_id):
     # 管理者でなければ自分の指示書のみ
     if not current_user.is_administrator and p.get("user_id") != current_user.email:
         return "アクセス権限がありません", 403
-    return render_template('main/prescription_view.html', p=p)
+    # 添付画像の署名付きURL生成（key と url をペアで渡す）
+    image_items = []
+    for key in (p.get("image_keys") or []):
+        try:
+            url = s3.generate_presigned_url(
+                'get_object',
+                Params={'Bucket': BUCKET_NAME, 'Key': key},
+                ExpiresIn=3600
+            )
+            image_items.append({"key": key, "url": url})
+        except Exception:
+            pass
+    # 添付ファイル（ZIP等）の署名付きURL生成
+    file_items = []
+    for key in (p.get("s3_keys") or []):
+        try:
+            url = s3.generate_presigned_url(
+                'get_object',
+                Params={'Bucket': BUCKET_NAME, 'Key': key},
+                ExpiresIn=3600
+            )
+            import os
+            file_items.append({"key": key, "url": url, "name": os.path.basename(key)})
+        except Exception:
+            pass
+    # 削除権限：管理者 or アップロードした医院
+    can_delete = (
+        current_user.is_administrator
+        or p.get("user_id") == current_user.email
+        or (p.get("clinic_id") and p.get("clinic_id") == getattr(current_user, "clinic_id", None))
+    )
+    return render_template('main/prescription_view.html', p=p, image_items=image_items, file_items=file_items, can_delete=can_delete)
+
+
+@bp.route('/prescription/delete_file/<prescription_id>', methods=['POST'])
+@login_required
+def delete_prescription_file(prescription_id):
+    from flask import jsonify
+    prescriptions_table = current_app.config["PRESCRIPTIONS_TABLE"]
+    resp = prescriptions_table.get_item(Key={"prescription_id": prescription_id})
+    p = resp.get("Item")
+    if not p:
+        return jsonify({"error": "指示書が見つかりません"}), 404
+
+    can_delete = (
+        current_user.is_administrator
+        or p.get("user_id") == current_user.email
+        or (p.get("clinic_id") and p.get("clinic_id") == getattr(current_user, "clinic_id", None))
+    )
+    if not can_delete:
+        return jsonify({"error": "権限がありません"}), 403
+
+    s3_key  = request.form.get("s3_key")
+    file_type = request.form.get("file_type")  # "image" or "file"
+    if not s3_key:
+        return jsonify({"error": "キーが指定されていません"}), 400
+
+    try:
+        s3.delete_object(Bucket=BUCKET_NAME, Key=s3_key)
+    except Exception as e:
+        return jsonify({"error": f"S3削除エラー: {str(e)}"}), 500
+
+    if file_type == "image":
+        new_keys = [k for k in (p.get("image_keys") or []) if k != s3_key]
+        prescriptions_table.update_item(
+            Key={"prescription_id": prescription_id},
+            UpdateExpression="SET image_keys = :keys",
+            ExpressionAttributeValues={":keys": new_keys}
+        )
+    else:
+        new_keys = [k for k in (p.get("s3_keys") or []) if k != s3_key]
+        prescriptions_table.update_item(
+            Key={"prescription_id": prescription_id},
+            UpdateExpression="SET s3_keys = :keys",
+            ExpressionAttributeValues={":keys": new_keys}
+        )
+
+    return jsonify({"success": True})
 
 
 @bp.route('/clinic', methods=['GET'])
 @login_required
 def clinic_dashboard():
-    return render_template('main/clinic_dashboard.html')
+    clinic_name = getattr(current_user, 'sender_name', '') or getattr(current_user, 'display_name', '') or '歯科医院メニュー'
+    return render_template('main/clinic_dashboard.html', clinic_name=clinic_name)
+
+
+@bp.route('/clinic/view/<path:user_id>', methods=['GET'])
+@login_required
+def clinic_view(user_id):
+    if not current_user.is_administrator:
+        abort(403)
+    users_table = current_app.config["HOERO_USERS_TABLE"]
+    resp = users_table.get_item(Key={"user_id": user_id})
+    clinic = resp.get("Item")
+    if not clinic:
+        abort(404)
+    prescriptions_table = current_app.config["PRESCRIPTIONS_TABLE"]
+    from boto3.dynamodb.conditions import Key as DKey
+    # clinic_id GSI を優先し、なければ user_id GSI にフォールバック
+    clinic_id_val = clinic.get("clinic_id")
+    try:
+        if clinic_id_val:
+            p_resp = prescriptions_table.query(
+                IndexName="clinic_id-created_at-index",
+                KeyConditionExpression=DKey("clinic_id").eq(clinic_id_val),
+                ScanIndexForward=False,
+            )
+        else:
+            raise Exception("clinic_id なし")
+    except Exception:
+        p_resp = prescriptions_table.query(
+            IndexName="user_id-created_at-index",
+            KeyConditionExpression=DKey("user_id").eq(user_id),
+            ScanIndexForward=False,
+        )
+    prescriptions = p_resp.get("Items", [])
+    return render_template('main/clinic_view.html', clinic=clinic, prescriptions=prescriptions)
+
+
+@bp.route('/clinic/list', methods=['GET'])
+@login_required
+def clinic_list():
+    if not current_user.is_administrator:
+        abort(403)
+    users_table = current_app.config["HOERO_USERS_TABLE"]
+    clinics = []
+    scan_kwargs = {"FilterExpression": Attr('administrator').ne(1)}
+    while True:
+        resp = users_table.scan(**scan_kwargs)
+        clinics.extend(resp.get('Items', []))
+        last = resp.get("LastEvaluatedKey")
+        if not last:
+            break
+        scan_kwargs["ExclusiveStartKey"] = last
+    clinics.sort(key=lambda x: x.get('clinic_id') or '')
+    return render_template('main/clinic_list.html', clinics=clinics)
+
+
+@bp.route('/clinic/new', methods=['GET', 'POST'])
+@login_required
+def clinic_new():
+    if not current_user.is_administrator:
+        abort(403)
+    users_table = current_app.config["HOERO_USERS_TABLE"]
+
+    if request.method == 'POST':
+        from werkzeug.security import generate_password_hash
+
+        account_type = request.form.get('account_type', 'clinic')  # 'clinic' or 'lab'
+        email       = request.form.get('email', '').strip()
+        password    = request.form.get('password', '').strip()
+        sender_name = request.form.get('sender_name', '').strip()
+        full_name   = request.form.get('full_name', '').strip()
+        phone       = request.form.get('phone', '').strip()
+        postal_code = request.form.get('postal_code', '').strip()
+        prefecture  = request.form.get('prefecture', '').strip()
+        address     = request.form.get('address', '').strip()
+        building    = request.form.get('building', '').strip()
+        dentists    = [d.strip() for d in request.form.getlist('dentists[]') if d.strip()]
+
+        if not email or not password or not sender_name:
+            flash('名称・メールアドレス・パスワードは必須です。')
+            return redirect(url_for('main.clinic_new'))
+
+        # メール重複チェック
+        existing = users_table.get_item(Key={'user_id': email}).get('Item')
+        if existing:
+            flash('そのメールアドレスはすでに登録されています。')
+            return redirect(url_for('main.clinic_new'))
+
+        # clinic_id 自動採番
+        # 歯科医院: D001, D002 … （DL を除く D のみ）
+        # 歯科技工所: DL001, DL002 …
+        all_items = []
+        scan_kw = {}
+        while True:
+            resp = users_table.scan(**scan_kw)
+            all_items.extend(resp.get('Items', []))
+            last = resp.get('LastEvaluatedKey')
+            if not last:
+                break
+            scan_kw['ExclusiveStartKey'] = last
+
+        if account_type == 'lab':
+            existing_ids = [item.get('clinic_id', '') for item in all_items
+                            if item.get('clinic_id', '').startswith('DL')]
+            max_num = max((int(cid[2:]) for cid in existing_ids if cid[2:].isdigit()), default=0)
+            clinic_id = f"DL{max_num + 1:03d}"
+        else:
+            existing_ids = [item.get('clinic_id', '') for item in all_items
+                            if item.get('clinic_id', '').startswith('D') and not item.get('clinic_id', '').startswith('DL')]
+            max_num = max((int(cid[1:]) for cid in existing_ids if cid[1:].isdigit()), default=0)
+            clinic_id = f"D{max_num + 1:03d}"
+
+        now = datetime.now(pytz_timezone('Asia/Tokyo')).isoformat()
+        users_table.put_item(Item={
+            'user_id':       email,
+            'email':         email,
+            'sender_name':   sender_name,
+            'display_name':  sender_name,
+            'full_name':     full_name,
+            'phone':         phone,
+            'postal_code':   postal_code,
+            'prefecture':    prefecture,
+            'address':       address,
+            'building':      building,
+            'password_hash': generate_password_hash(password),
+            'administrator': 0,
+            'account_type':  account_type,
+            'clinic_id':     clinic_id,
+            'dentists':      dentists,
+            'created_at':    now,
+            'updated_at':    now,
+        })
+        flash(f'{sender_name}（{clinic_id}）を登録しました。')
+        return redirect(url_for('main.clinic_list'))
+
+    return render_template('main/clinic_new.html')
 
 
 @bp.route('/prescription', methods=['GET'])
@@ -1072,11 +1291,13 @@ def prescription():
     dentists = getattr(current_user, "dentists", [])
     sender_name = getattr(current_user, "sender_name", "") or ""
     user_email = getattr(current_user, "email", "") or ""
+    full_name = getattr(current_user, "full_name", "") or ""
     return render_template(
         'main/prescription.html',
         dentists=dentists,
         sender_name=sender_name,
         user_email=user_email,
+        default_user_name=full_name,
     )
 
 
@@ -1115,7 +1336,9 @@ def meziro_upload():
     appointment_hour = request.form.get('appointmentHour', '')
     project_type     = request.form.get('projectType', '')
     crown_type       = request.form.get('crown_type', '')
-    teeth_raw        = request.form.get('teeth', '[]')
+    teeth_raw          = request.form.get('teeth', '[]')
+    teeth_abutment_raw = request.form.get('teeth_abutment', '[]')
+    teeth_missing_raw  = request.form.get('teeth_missing', '[]')
     shade            = request.form.get('shade', '')
     message          = request.form.get('userMessage', '')
 
@@ -1127,6 +1350,22 @@ def meziro_upload():
     except Exception as e:
         log.warning("teeth のJSONパース失敗: raw=%s err=%s", teeth_raw[:200], e)
         teeth = []
+    try:
+        teeth_abutment = json.loads(teeth_abutment_raw)
+        if not isinstance(teeth_abutment, list): teeth_abutment = []
+    except Exception:
+        teeth_abutment = []
+    try:
+        teeth_missing = json.loads(teeth_missing_raw)
+        if not isinstance(teeth_missing, list): teeth_missing = []
+    except Exception:
+        teeth_missing = []
+    teeth_fabrication_raw = request.form.get('teeth_fabrication', '[]')
+    try:
+        teeth_fabrication = json.loads(teeth_fabrication_raw)
+        if not isinstance(teeth_fabrication, list): teeth_fabrication = []
+    except Exception:
+        teeth_fabrication = []
 
     # フォーム要約ログ（個人情報はマスキング）
     masked_email = (user_email[:2] + "***@***") if user_email else ""
@@ -1401,6 +1640,19 @@ email: shibuya8020@gmail.com
         # 指示書をDynamoDBに保存
         try:
             prescriptions_table = current_app.config["PRESCRIPTIONS_TABLE"]
+
+            # clinic_id を user_id（メール）から取得
+            clinic_id_for_prescription = None
+            if current_user.is_authenticated:
+                clinic_id_for_prescription = getattr(current_user, 'clinic_id', None)
+            if not clinic_id_for_prescription:
+                try:
+                    users_table = current_app.config["HOERO_USERS_TABLE"]
+                    u = users_table.get_item(Key={'user_id': user_email}).get('Item', {})
+                    clinic_id_for_prescription = u.get('clinic_id')
+                except Exception:
+                    pass
+
             prescription_item = {
                 "prescription_id": id_str,
                 "user_id":         user_email,
@@ -1414,6 +1666,9 @@ email: shibuya8020@gmail.com
                 "project_type":    project_type,
                 "crown_type":      crown_type,
                 "teeth":           teeth,
+                "teeth_abutment":     teeth_abutment,
+                "teeth_missing":      teeth_missing,
+                "teeth_fabrication":  teeth_fabrication,
                 "shade":           shade,
                 "message":         message,
                 "s3_keys":         [url_for('main.meziro_download', key=k.split('/meziro/download/')[-1], _external=False) if '/meziro/download/' in k else k for k in uploaded_urls],
@@ -1422,6 +1677,9 @@ email: shibuya8020@gmail.com
                 "created_at":      received_at_str,
                 "updated_at":      received_at_str,
             }
+            if clinic_id_for_prescription:
+                prescription_item["clinic_id"] = clinic_id_for_prescription
+
             prescriptions_table.put_item(Item=prescription_item)
             log.info("指示書をDynamoDBに保存: prescription_id=%s", id_str)
         except Exception as e:

--- a/views/users.py
+++ b/views/users.py
@@ -277,7 +277,7 @@ def account_me():
     if form.validate_on_submit():
         # フォームの内容で item を更新
         item["display_name"] = form.display_name.data
-        item["email"]        = form.email.data
+        # email はログインIDのため更新不可（変更は管理者対応）
         item["full_name"]    = form.full_name.data
         item["sender_name"]  = form.sender_name.data
         item["phone"]        = form.phone.data
@@ -412,7 +412,7 @@ def account(user_id):
 
     if form.validate_on_submit():
         item["display_name"] = form.display_name.data
-        item["email"]        = form.email.data
+        # email はログインIDのため更新不可（変更は管理者対応）
         item["full_name"]    = form.full_name.data
         item["sender_name"]  = form.sender_name.data
         item["phone"]        = form.phone.data


### PR DESCRIPTION
## Summary
- 歯牙グリッドを3状態→4状態に変更（空白/支台歯/欠損部/製作部）
- 患者名・フリガナを姓・名に分割
- 製作物セレクトを歯科医院/歯科技工所グループに整理
- 指示書・一覧・詳細ページに「医院トップへ」ボタン追加
- ZIPダウンロードを管理者のみに制限
- 添付ファイル・画像の削除機能追加
- メールアドレスを読み取り専用に変更
- アカウント名クリックで医院トップへ遷移
- meziro_uploadとWeb歯科技工指示書のUI統一